### PR TITLE
Fix for Put(), new AddTag() and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ func main() {
 		panic(err)
 	}
 
+	err = client.AddTag("DocType", doc, "MyTag")
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	fmt.Println(doc)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -26,3 +26,8 @@ func main() {
 	fmt.Println(doc)
 }
 ```
+
+## Running Tests
+```
+# URL="https://demo.erpnext.com" KEY="..." SECRET="..."  go test
+```

--- a/client.go
+++ b/client.go
@@ -215,3 +215,35 @@ func (c *Client) Put(docType string, name string, doc Document) (Document, error
 
 	return respStruct.Data, nil
 }
+
+// AddTag adds tag to document
+func (c *Client) AddTag(docType string, doc Document, tag string) error {
+	u, err := url.Parse(c.URL)
+	if err != nil {
+		return err
+	}
+
+	u.Path = "/api/method/frappe.desk.doctype.tag.tag.add_tag"
+	q := u.Query()
+	q.Add("dn", doc.GetAsString("name"))
+	q.Add("dt", docType)
+	q.Add("tag", tag)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "token "+c.Key+":"+c.Secret)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	} else {
+		return fmt.Errorf("HTTP Status Code: %d (%s)", resp.StatusCode, resp.Status)
+	}
+}

--- a/client.go
+++ b/client.go
@@ -189,7 +189,7 @@ func (c *Client) Put(docType string, name string, doc Document) (Document, error
 		return nil, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, u.String(), buf)
+	req, err := http.NewRequest(http.MethodPut, u.String(), buf)
 	if err != nil {
 		return nil, err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,87 @@
+package frappe
+
+import (
+	"log"
+	"os"
+	"testing"
+)
+
+func getClient() *Client {
+	url := os.Getenv("URL")
+	key := os.Getenv("KEY")
+	secret := os.Getenv("SECRET")
+
+	return &Client{
+		URL:    url,
+		Key:    key,
+		Secret: secret,
+	}
+}
+
+func TestClient_GetAll(t *testing.T) {
+	client := getClient()
+
+	var fields []string
+	var filters []Filter
+
+	_, err := client.GetAll("Lead", fields, filters, 0, 0)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func TestClient_Post(t *testing.T) {
+	client := getClient()
+
+	doc := NewDocument()
+	doc["lead_name"] = "Name"
+
+	_, err := client.Post("Lead", doc)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func TestClient_Get(t *testing.T) {
+	client := getClient()
+
+	doc := NewDocument()
+	doc["lead_name"] = "Name"
+
+	r1, err := client.Post("Lead", doc)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var filter []string
+	r2, err := client.Get("Lead", r1.GetAsString("name"), filter)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if r1.GetAsString("name") != r2.GetAsString("name") {
+		log.Fatal("Lead mismatch")
+	}
+}
+
+func TestClient_Put(t *testing.T) {
+	client := getClient()
+
+	doc := NewDocument()
+	doc["lead_name"] = "Name"
+
+	r1, err := client.Post("Lead", doc)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	r1.Set("lead_name", "NewName")
+	r2, err := client.Put("Lead", r1.GetAsString("name"), r1)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if r1.GetAsString("lead_name") != r2.GetAsString("lead_name") {
+		log.Fatal("Lead name mismatch")
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -85,3 +85,20 @@ func TestClient_Put(t *testing.T) {
 		log.Fatal("Lead name mismatch")
 	}
 }
+
+func TestClient_AddTag(t *testing.T) {
+	client := getClient()
+
+	doc := NewDocument()
+	doc["lead_name"] = "Name"
+
+	lead, err := client.Post("Lead", doc)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = client.AddTag("Lead", lead, "MyTag")
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/frappe.go
+++ b/frappe.go
@@ -1,5 +1,7 @@
 package frappe
 
+import "fmt"
+
 // Document represents a Frappe document
 type Document map[string]interface{}
 
@@ -11,6 +13,11 @@ func NewDocument() Document {
 // Get returns the value of a field
 func (d Document) Get(field string) interface{} {
 	return d[field]
+}
+
+// GetAsString returns the value of a field as string
+func (d Document) GetAsString(field string) string {
+	return fmt.Sprintf("%v", d[field])
 }
 
 // Set sets the value of a field


### PR DESCRIPTION
1. There was a bug in `Put` method. Instead of `http.MethodPut` it was using `http.MethodPost`. This was fixed
2. Tests were added
3. `GetAsString` was added to `Document` cause casting interface to string seems to be a common case for most of the projects I'm planning to use this library with

P.S: Check commits one-by-one to get better idea of what was changed